### PR TITLE
Support non-CUDA systems

### DIFF
--- a/pixeldrawer.py
+++ b/pixeldrawer.py
@@ -35,8 +35,9 @@ class PixelDrawer(DrawingInterface):
         # gamma = 1.0
 
         # Use GPU if available
-        pydiffvg.set_use_gpu(torch.cuda.is_available())
-        device = torch.device('cuda')
+        cuda_available = torch.cuda.is_available()
+        pydiffvg.set_use_gpu(cuda_available)
+        device = torch.device('cuda' if cuda_available else 'cpu')
         pydiffvg.set_device(device)
 
         canvas_width, canvas_height = self.canvas_width, self.canvas_height


### PR DESCRIPTION
The "# Use GPU if available" section in `load_model` is accidentally forcing the use of CUDA.